### PR TITLE
keepalive fix

### DIFF
--- a/BitcoinMiner.py
+++ b/BitcoinMiner.py
@@ -235,7 +235,7 @@ class BitcoinMiner():
 			if result['error']:	raise RPCError(result['error']['message'])
 			return (connection, result)
 		finally:
-			if not result or not response or response.getheader('connection', '') != 'keep-alive':
+			if not result or not response or response.getheader('connection', '') == 'close':
 				connection.close()
 				connection = None
 


### PR DESCRIPTION
Don't implicitly close the RPC connection unless we get a Connection: close header. In HTTP 1.1, the server is not required and often does not send a Connection: keep-alive header. That is only required in HTTP 1.0.
