### PR TITLE
Add --quiet option; suppress all output except hash rate display

### DIFF
--- a/BitcoinMiner.py
+++ b/BitcoinMiner.py
@@ -147,7 +147,8 @@ class BitcoinMiner():
 			self.failure('At least one server is required')
 		else: self.setpool(self.servers[0])
 
-	def say(self, format, args=()):
+	def say(self, format, args=(), sayQuiet=False):
+		if self.options.quiet and not sayQuiet: return
 		with self.outputLock:
 			p = format % args
 			pool = self.pool[3]+' ' if self.pool else ''
@@ -161,6 +162,9 @@ class BitcoinMiner():
 		if not self.options.verbose:
 			format = '%s, %s\n' % (datetime.now().strftime(TIME_FORMAT), format)
 		self.say(format, args)
+		
+	def sayQuiet(self, format, args=()):
+		self.say(format, args, True)
 
 	def exit(self):
 		self.stop = True
@@ -170,7 +174,7 @@ class BitcoinMiner():
 		estRate = Decimal(estRate) / 1000
 		totShares = self.shareCount[1] + self.shareCount[0]
 		totSharesE = max(totShares, totShares, 1)
-		self.say('[%.03f MH/s (~%d MH/s)] [Rej: %d/%d (%d%%)]', (rate, round(estRate), self.shareCount[0], totShares, self.shareCount[0] * 100 / totSharesE))
+		self.sayQuiet('[%.03f MH/s (~%d MH/s)] [Rej: %d/%d (%d%%)]', (rate, round(estRate), self.shareCount[0], totShares, self.shareCount[0] * 100 / totSharesE))
 
 	def failure(self, message):
 		print '\n%s' % message

--- a/README.mkd
+++ b/README.mkd
@@ -5,6 +5,7 @@ Options:
   --version             show program's version number and exit
   -h, --help            show this help message and exit
   --verbose             verbose output, suitable for redirection to log file
+  -q, --quiet           suppress all output except hash rate display
 
   Miner Options:
     -r RATE, --rate=RATE

--- a/poclbm.py
+++ b/poclbm.py
@@ -9,6 +9,7 @@ from optparse import OptionGroup
 usage = "usage: %prog [OPTION]... SERVER...\nSERVER is one or more [http[s]://]user:pass@host:port"
 parser = OptionParser(version=USER_AGENT, usage=usage)
 parser.add_option('--verbose',        dest='verbose',    action='store_true', help='verbose output, suitable for redirection to log file')
+parser.add_option('-q', '--quiet',    dest='quiet',      action='store_true', help='suppress all output except hash rate display')
 
 group = OptionGroup(parser, "Miner Options")
 group.add_option('-r', '--rate',      dest='rate',       default=1,           help='hash rate display interval in seconds, default=1', type='float')


### PR DESCRIPTION
Suppresses ALL output except:

server [172.934 MH/s (~113 MH/s)] [Rej: 0/1 (0%)]

I run several miners and tail each to show many status at once.
Individual accept/reject are hidden but cumulatives are still shown
Server changes are hidden but current server is still shown at left of hash rate display
