### PR TITLE
Renamed --verbose to -c, --clean

### DIFF
--- a/BitcoinMiner.py
+++ b/BitcoinMiner.py
@@ -157,14 +157,14 @@ class BitcoinMiner():
 		with self.outputLock:
 			p = format % args
 			pool = self.pool[4]+' ' if self.pool else ''
-			if self.options.verbose:
+			if self.options.clean:
 				print '%s%s,' % (pool, datetime.now().strftime(TIME_FORMAT)), p
 			else:
 				sys.stdout.write('\r%s\r%s%s' % (' '*80, pool, p))
 			sys.stdout.flush()
 
 	def sayLine(self, format, args=()):
-		if not self.options.verbose:
+		if not self.options.clean:
 			format = '%s, %s\n' % (datetime.now().strftime(TIME_FORMAT), format)
 		self.say(format, args)
 		
@@ -186,7 +186,7 @@ class BitcoinMiner():
 		self.exit()
 
 	def diff1Found(self, hash, target):
-		if self.options.verbose and target < 0xFFFF0000L:
+		if self.options.clean and target < 0xFFFF0000L:
 			self.sayLine('checking %s <= %s', (hash, target))
 
 	def blockFound(self, hash, accepted):

--- a/README.mkd
+++ b/README.mkd
@@ -5,7 +5,7 @@ SERVER is one or more [http[s]://]user:pass@host:port          (required)
 Options:
   --version             show program's version number and exit
   -h, --help            show this help message and exit
-  --verbose             verbose output, suitable for redirection to log file
+  -c, --clean           clean output, suitable for redirection to log file
   -q, --quiet           suppress all output except hash rate display
   --no-server-failbacks
                         disable using failback hosts provided by server

--- a/poclbm.py
+++ b/poclbm.py
@@ -8,7 +8,7 @@ from optparse import OptionGroup
 
 usage = "usage: %prog [OPTION]... SERVER[#tag]...\nSERVER is one or more [http[s]://]user:pass@host:port          (required)\n[#tag] is a per SERVER user friendly name displayed in stats   (optional)"
 parser = OptionParser(version=USER_AGENT, usage=usage)
-parser.add_option('--verbose',        dest='verbose',    action='store_true', help='verbose output, suitable for redirection to log file')
+parser.add_option('-c', '--clean',    dest='clean',      action='store_true', help='clean output, suitable for redirection to log file')
 parser.add_option('-q', '--quiet',    dest='quiet',      action='store_true', help='suppress all output except hash rate display')
 
 group = OptionGroup(parser, "Miner Options")


### PR DESCRIPTION
saving for later, would prefer to have --no-timestamp merged first

Mostly so I can add short code '-c' without being confused with '--vectors'
