### PR TITLE
Add --no-timestamp; makes timestamps optional but default on

### DIFF
--- a/BitcoinMiner.py
+++ b/BitcoinMiner.py
@@ -155,18 +155,21 @@ class BitcoinMiner():
 	def say(self, format, args=(), sayQuiet=False):
 		if self.options.quiet and not sayQuiet: return
 		with self.outputLock:
-			p = format % args
-			pool = self.pool[4]+' ' if self.pool else ''
+			outp = format % args
+			if self.options.outStamp:
+				outp = datetime.now().strftime(TIME_FORMAT) + ' ' + outp
+			if self.pool:
+				outp = self.pool[4] + ' ' + outp
 			if self.options.verbose:
-				print '%s%s,' % (pool, datetime.now().strftime(TIME_FORMAT)), p
+				print outp
 			else:
-				sys.stdout.write('\r%s\r%s%s' % (' '*80, pool, p))
+				sys.stdout.write('\r%s\r%s' % (' '*80, outp))
 			sys.stdout.flush()
 
 	def sayLine(self, format, args=()):
 		if not self.options.verbose:
-			format = '%s, %s\n' % (datetime.now().strftime(TIME_FORMAT), format)
-		self.say(format, args)
+			self.say(format + '\n', args)
+		else:   self.say(format       , args)
 		
 	def sayQuiet(self, format, args=()):
 		self.say(format, args, True)

--- a/README.mkd
+++ b/README.mkd
@@ -7,6 +7,7 @@ Options:
   -h, --help            show this help message and exit
   --verbose             verbose output, suitable for redirection to log file
   -q, --quiet           suppress all output except hash rate display
+  -T, --no-timestamp    removes timestamp from output
   --no-server-failbacks
                         disable using failback hosts provided by server
 

--- a/poclbm.py
+++ b/poclbm.py
@@ -10,6 +10,7 @@ usage = "usage: %prog [OPTION]... SERVER[#tag]...\nSERVER is one or more [http[s
 parser = OptionParser(version=USER_AGENT, usage=usage)
 parser.add_option('--verbose',        dest='verbose',    action='store_true', help='verbose output, suitable for redirection to log file')
 parser.add_option('-q', '--quiet',    dest='quiet',      action='store_true', help='suppress all output except hash rate display')
+parser.add_option('-T', '--no-timestamp', dest='outStamp',  action='store_false', help='removes timestamp from output', default=True)
 
 group = OptionGroup(parser, "Miner Options")
 group.add_option('-r', '--rate',      dest='rate',       default=1,           help='hash rate display interval in seconds, default=1', type='float')


### PR DESCRIPTION
Also hash rate display looks cool with rolling timestamp

Deepbit 09/07/2011 03:55:29 [184.868 MH/s (~390 MH/s)] [Rej: 0/1 (0%)]
