### PR TITLE
Sliding window long polling rate limit

### DIFF
--- a/HttpTransport.py
+++ b/HttpTransport.py
@@ -136,8 +136,13 @@ class HttpTransport(Transport):
 
 	def long_poll_thread(self):
 		last_host = None
+		times = []
 		while True:
-			sleep(1)
+			# limit to 5 in the last 5 seconds
+			times.append(time())
+			if len(times) > 5:
+				time_5_ago = times.pop(0)
+				sleep(max(0, min(1, time_5_ago + 5 - time())))
 			url = self.long_poll_url
 			if url != '':
 				proto = self.proto

--- a/HttpTransport.py
+++ b/HttpTransport.py
@@ -183,7 +183,7 @@ class HttpTransport(Transport):
 	def set_server(self, server):
 		super(HttpTransport, self).set_server(server)
 		user, pwd = server[1:3]
-		self.headers = {"User-Agent": self.user_agent, "Authorization": 'Basic ' + b64encode('%s:%s' % (user, pwd)), 'X-Work-Identifier': 1}
+		self.headers = {"User-Agent": self.user_agent, "Authorization": 'Basic ' + b64encode('%s:%s' % (user, pwd)), 'X-Work-Identifier': '1'}
 		self.long_poll_url = ''
 		if self.connection:
 			self.connection.close()

--- a/HttpTransport.py
+++ b/HttpTransport.py
@@ -183,7 +183,7 @@ class HttpTransport(Transport):
 	def set_server(self, server):
 		super(HttpTransport, self).set_server(server)
 		user, pwd = server[1:3]
-		self.headers = {"User-Agent": self.user_agent, "Authorization": 'Basic ' + b64encode('%s:%s' % (user, pwd))}
+		self.headers = {"User-Agent": self.user_agent, "Authorization": 'Basic ' + b64encode('%s:%s' % (user, pwd)), 'X-Work-Identifier': 1}
 		self.long_poll_url = ''
 		if self.connection:
 			self.connection.close()
@@ -215,6 +215,7 @@ class HttpTransport(Transport):
 			job.f          = np.zeros(8, np.uint32)
 			job.state2     = partial(job.state, job.merkle_end, job.time, job.difficulty, job.f)
 			job.targetQ    = 2**256 / int(''.join(list(chunks(work['target'], 2))[::-1]), 16)
+			job.identifier = (1, work['identifier']) if 'identifier' in work else (0, job.header[25:29])
 
 			calculateF(job.state, job.merkle_end, job.time, job.difficulty, job.f, job.state2)
 

--- a/HttpTransport.py
+++ b/HttpTransport.py
@@ -136,13 +136,7 @@ class HttpTransport(Transport):
 
 	def long_poll_thread(self):
 		last_host = None
-		times = []
 		while True:
-			# limit to 5 in the last 5 seconds
-			times.append(time())
-			if len(times) > 5:
-				time_5_ago = times.pop(0)
-				sleep(max(0, min(1, time_5_ago + 5 - time())))
 			url = self.long_poll_url
 			if url != '':
 				proto = self.proto
@@ -170,12 +164,17 @@ class HttpTransport(Transport):
 					say_line('long poll: new block %s%s', (result['result']['data'][56:64], result['result']['data'][48:56]))
 				except NotAuthorized:
 					say_line('long poll: Wrong username or password')
+					sleep(.5)
 				except RPCError as e:
 					say_line('long poll: %s', e)
+					sleep(.5)
 				except (IOError, httplib.HTTPException, ValueError):
 					say_line('long poll: IO error')
 					#traceback.print_exc()
 					self.close_lp_connection()
+					sleep(.5)
+			else:
+				sleep(.5)
 
 	def stop(self):
 		self.should_stop = True

--- a/Transport.py
+++ b/Transport.py
@@ -117,8 +117,8 @@ class Transport(object):
 			self.miner.work_queue.put(work)
 			if work:
 				self.update = False; self.last_work = time()
-				if self.last_block != work.header[25:29]:
-					self.last_block = work.header[25:29]
+				if self.last_block != work.identifier:
+					self.last_block = work.identifier
 					self.clear_result_queue()
 
 	def clear_result_queue(self):


### PR DESCRIPTION
Decrease stales (especially when using p2pool) by using a sliding window to allow fast long polling responses without potentially overloading the pool server.
