### PR TITLE
Fix: poclbm failing since the last difficulty change, bug in true difficulty calculation

### DIFF
--- a/Transport.py
+++ b/Transport.py
@@ -91,7 +91,7 @@ class Transport(object):
 		self.difficulty = difficulty
 		bits = hex(difficulty)
 		bits = bits[2:len(bits) - 1]
-		bits += ('0' * (8 - len(bits)))
+		bits = ('0' * (8 - len(bits))) + bits
 		bits = ''.join(list(chunks(bits, 2))[::-1])
 		true_target = '%064x' % (int(bits[2:], 16) * 2 ** (8 * (int(bits[:2], 16) - 3)),)
 		true_target = ''.join(list(chunks(true_target, 2))[::-1])


### PR DESCRIPTION
Since the last difficulty change poclbm has been failing with errors like:

File "/home/jglauche/src/poclbm/Transport.py", line 98, in set_difficulty
  self.true_target = np.array(unpack('IIIIIIII', true_target.decode('hex')), dtype=np.uint32)
error: unpack requires a string argument of length 32

The problem is that we're extracting bits from the block wrong if the
data in the block header starts with a 0 in hex, and this causes the
true difficulty computation to error out. Fix this by handling leading
zeroes correctly.
