### PR TITLE
Wrap socket type with a class instead of a function.

### DIFF
--- a/poclbm.py
+++ b/poclbm.py
@@ -14,7 +14,7 @@ class LongPollingSocket(socket.socket):
 	Socket wrapper to enable socket.TCP_NODELAY and KEEPALIVE
 	"""
 	def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0):
-		super(LongPollingSocket, self).__init__(family, type, proto=0)
+		super(LongPollingSocket, self).__init__(family, type, proto)
 		if type == socket.SOCK_STREAM:
 			self.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 			self.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)

--- a/poclbm.py
+++ b/poclbm.py
@@ -9,16 +9,18 @@ import log
 import socket
 
 
-# Socket wrapper to enable socket.TCP_NODELAY and KEEPALIVE
-realsocket = socket.socket
-def socketwrap(family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0):
-	sockobj = realsocket(family, type, proto)
-	if type == socket.SOCK_STREAM:
-		sockobj.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-		sockobj.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-	sockobj.settimeout(5)
-	return sockobj
-socket.socket = socketwrap
+class LongPollingSocket(socket.socket):
+	"""
+	Socket wrapper to enable socket.TCP_NODELAY and KEEPALIVE
+	"""
+	def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0):
+		super(LongPollingSocket, self).__init__(family, type, proto=0)
+		if type == socket.SOCK_STREAM:
+			self.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+			self.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+		self.settimeout(5)
+
+socket.socket = LongPollingSocket
 
 
 usage = "usage: %prog [OPTION]... SERVER[#tag]...\nSERVER is one or more [http[s]|stratum://]user:pass@host:port          (required)\n[#tag] is a per SERVER user friendly name displayed in stats (optional)"


### PR DESCRIPTION
By wrapping the `socket.socket` type with a function, we've been emulating only the wrapped type's constructor and not the wrapped type itself. This won't work if we wish to enable long polling for SOCKS connections with the SocksiPy library as this library imports and attempts to construct a class that inherits from the `socket.socket` type.

Original wrapper function was added in 6cf0bc72ae31d2a18e5a8f929c700440e33f98ac, but the issue this pull request attempts to address was triggered by a change in module import order in a5ab744770e877dad32cc40fa1f21e7c6daf3970, where SocksiPy wraps poclbm's own socket wrapper, where before it had been wrapping the system-provided socket type. This pull request addresses m0mchil/poclbm#56.  If we don't need long polling on SOCKS, live-mining/poclbm@ce05212c53a30386da94a5aebd1d581d5421a354 is also a fix for the immediate issue described in issue 56.
