### PR TITLE
Workaround for standard strictness enforcement on OS X

### DIFF
--- a/OpenCLMiner.py
+++ b/OpenCLMiner.py
@@ -1,3 +1,4 @@
+from sys import platform as _platform
 from Miner import Miner
 from Queue import Empty
 from hashlib import md5
@@ -31,6 +32,16 @@ if PYOPENCL:
 			print '\nNo OpenCL platforms\n'
 	except Exception:
 		print '\nNo OpenCL\n'
+
+def is_osx():
+	if 'darwin' == _platform:
+		return True
+	return False
+
+def vectors_definition():
+	if is_osx():
+		return '-D VECTORS'
+	return '-DVECTORS'
 
 def is_amd(platform):
 	if 'amd' in platform.name.lower():
@@ -149,7 +160,7 @@ class OpenCLMiner(Miner):
 	def mining_thread(self):
 		say_line('started OpenCL miner on platform %d, device %d (%s)', (self.options.platform, self.device_index, self.device_name))
 
-		(self.defines, rate_divisor, hashspace) = ('-DVECTORS', 500, 0x7FFFFFFF) if self.vectors else ('', 1000, 0xFFFFFFFF)
+		(self.defines, rate_divisor, hashspace) = (vectors_definition(), 500, 0x7FFFFFFF) if self.vectors else ('', 1000, 0xFFFFFFFF)
 		self.defines += (' -DOUTPUT_SIZE=' + str(self.output_size))
 		self.defines += (' -DOUTPUT_MASK=' + str(self.output_size - 1))
 

--- a/OpenCLMiner.py
+++ b/OpenCLMiner.py
@@ -1,4 +1,4 @@
-from sys import platform as _platform
+from detect import MACOSX
 from Miner import Miner
 from Queue import Empty
 from hashlib import md5
@@ -33,13 +33,8 @@ if PYOPENCL:
 	except Exception:
 		print '\nNo OpenCL\n'
 
-def is_osx():
-	if 'darwin' == _platform:
-		return True
-	return False
-
 def vectors_definition():
-	if is_osx():
+	if MACOSX:
 		return '-D VECTORS'
 	return '-DVECTORS'
 


### PR DESCRIPTION
Use platform specific logic to avoid known OS X pitfall; see http://wiki.tiker.net/OpenCLOddities
