### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -27,10 +27,10 @@ Options:
     -b FAILBACK, --failback=FAILBACK
                         attempt to fail back to the primary pool after N
                         seconds, default 60
-    --cutoff_temp=CUTOFF_TEMP
+    --cutoff-temp=CUTOFF_TEMP
                         (requires github.com/mjmvisser/adl3) temperature at
                         which to skip kernel execution, in C, default=95
-    --cutoff_interval=CUTOFF_INTERVAL
+    --cutoff-interval=CUTOFF_INTERVAL
                         (requires adl3) how long to not execute calculations
                         if CUTOFF_TEMP is reached, in seconds, default=0.01
     --no-server-failbacks


### PR DESCRIPTION
cutoff_temp option would error 'no such option'
it's cutoff-temp in the code.. and that didn't get an error for me (i've not installed ADL yet, so don't know if it'll work)...
